### PR TITLE
Mac jucer file update: Proj name & generic libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ Instructions [here](./README-Server.md)
     
 1. Install Java 8
 
-        $ brew tap caskroom versions
-        $ brew cask install homebrew/cask-versions/java8
+        $ brew tap homebrew/cask
+        $ brew tap AdoptOpenJDK/openjdk
+        $ brew cask install adoptopenjdk/openjdk/adoptopenjdk8
     
 1. Necessary Python support for Bazel builds
    

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ TODO: Expand startup for other platforms beyond MacOS
 Clone the project and initialize the submodules in 3rdParty.
 
     $ git clone --recurse-submodules https://github.com/artandlogic/vibrary.git
-        
+
 Or if you already have cloned the project
         
     $ git submodule update --init
@@ -39,15 +39,14 @@ Instructions [here](./README-Server.md)
     
         $ curl -L -O https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-darwin-x86_64.sh
         $ . bazel-0.24.1-installer-darwin-x86_64.sh
-       
-
+    
 1. Install Java 8
 
         $ brew tap caskroom versions
         $ brew cask install homebrew/cask-versions/java8
-       
-1. Necessary Python support for Bazel builds
     
+1. Necessary Python support for Bazel builds
+   
         $ pip install future
     
 ### Install other dependencies
@@ -57,7 +56,7 @@ Note that libarchive will not be linked by homebrew because macOS includes its o
 *WARNING*: The PostBuild script(s) in the Tools directory and `Vibrary.jucer` file have references to specific versions of these libraries and may need to be udpated after the install or `brew update`.
 
     $ brew install libssh libarchive
-    
+
 ### (Optional) Build Tensorflow
 
 The PreBuild scripts will check if TensorFlow needs to be built, but to manually build it yourself:
@@ -84,3 +83,72 @@ Currently there is only an Xcode exporter configured.
 Or to build and create an archive of the app, giving it a specific version
 
  `$ Tools/BuildMac.sh <version>` replacing version with the version number of the release. If no version is given the current version is bumped up one.
+
+
+
+## Linux (still under construction)
+
+### Create a virtual environment
+
+These instructions assume a Python environment based on [pip & virtualenv](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/) on an Ubuntu Linux distribution.   Start a new environment via
+
+```bash
+$ cd vibrary
+$ python3 -m venv env
+$ source env/bin/activate
+$ pip install --upgrade pip
+```
+
+### Install Tensorflow
+
+You can either [install a binary via `pip`](https://www.tensorflow.org/install/pip), such as the GPU-enabled version
+
+```
+$ pip install tensorflow-gpu==1.15
+```
+
+or you can perform the following steps to build from source:
+
+1. Install Bazel for TensorFlow build
+
+   Binary builds are available [here](https://github.com/bazelbuild/bazel/releases/tag/0.24.1).  A basic Linux download & build can proceed as follows:
+
+   ```bash
+   $ curl -LO https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh
+   $ chmod u+x bazel-0.24.1-installer-linux-x86_64.sh
+   ```
+
+   Then install either system-wide via 
+
+   ```$ sudo ./bazel-0.24.1-installer-linux-x86_64.sh```
+
+   or as a user-specific installation via 
+
+   ```$ ./bazel-0.24.1-installer-linux-x86_64.sh --user```
+
+1. Install Java 8. 
+
+   ```bash
+   $ sudo apt update
+   $ sudo apt install openjdk-8-jre-headless
+   ```
+
+1. Necessary Python support for Bazel builds
+
+   `$ pip install future`
+
+...**TODO:** add more for TF build from source.  For now, continuing based on pip binary install.
+
+### Install other dependencies
+
+```bash
+$ sudo apt install libssh-4 libarchive-tools
+```
+
+### Build Vibrary
+
+Run the `Projucer` JUCE app, and then choose "Open Existing Application" and select the `Vibrary.jucer` file in the `vibrary` directory, and then....
+
+**TODO:**... Seems the options to export are greyed-out.  Can't export.
+
+![JUCE_screenshot](/home/shawley/Downloads/JUCE_screenshot.png)

--- a/README.md
+++ b/README.md
@@ -73,10 +73,14 @@ The PreBuild scripts will check if Cnpy needs to be build, but to manually build
 
 ### Build Vibrary
 
-The `Tools/BuildMac.sh` takes care of this, but manual steps are outlined here.
+Run `Tools/BuildMac.sh`, which will perform multiple steps.  Manual steps are outlined below.
+By default the `BuildMac.sh` script shows little output.  To see the progress of the `BuildMac.sh` script, run (in another terminal window)
+
+    $ tail -f build.log
 
 Currently there is only an Xcode exporter configured.
 
+Manual build steps:
 1. Open Incubator1.jucer with Projucer
 1. Export the project files from Projucer (`command-shift-L`)
 1. Build with Xcode.

--- a/Tools/BuildMac.sh
+++ b/Tools/BuildMac.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-projectName=Incubator1
+projectName=Vibrary
 juceProject=$projectName.jucer
 
 echo juce project $juceProject

--- a/Vibrary.jucer
+++ b/Vibrary.jucer
@@ -134,8 +134,8 @@
       <FILE id="IUJqeD" name="MelFilter.cpp" compile="1" resource="0" file="Source/MelFilter.cpp"/>
       <FILE id="YzJnXk" name="MelFilter.h" compile="0" resource="0" file="Source/MelFilter.h"/>
       <GROUP id="{A6310410-E140-91C9-001E-5CE8F9F54FAA}" name="Model">
-        <FILE id="Tn26Qa" name="SortFile.cpp" compile="1" resource="0" file="/Users/shawley/github/vibrary/Source/SortFile.cpp"/>
-        <FILE id="GVXsEQ" name="SortFile.h" compile="0" resource="0" file="/Users/shawley/github/vibrary/Source/SortFile.h"/>
+        <FILE id="Tn26Qa" name="SortFile.cpp" compile="1" resource="0" file="Source/SortFile.cpp"/>
+        <FILE id="GVXsEQ" name="SortFile.h" compile="0" resource="0" file="Source/SortFile.h"/>
         <FILE id="L80SR0" name="Spectrogram.cpp" compile="1" resource="0" file="Source/Spectrogram.cpp"/>
         <FILE id="hAktFn" name="Spectrogram.h" compile="0" resource="0" file="Source/Spectrogram.h"/>
         <FILE id="I1A2M0" name="Tag.cpp" compile="1" resource="0" file="Source/Tag.cpp"/>
@@ -161,15 +161,15 @@
         <FILE id="prxoGb" name="Persistence.cpp" compile="1" resource="0" file="Source/Persistence.cpp"/>
         <FILE id="E6U4du" name="Persistence.h" compile="0" resource="0" file="Source/Persistence.h"/>
         <FILE id="X5McxC" name="SortFilesSource.cpp" compile="1" resource="0"
-              file="/Users/shawley/github/vibrary/Source/SortFilesSource.cpp"/>
+              file="Source/SortFilesSource.cpp"/>
         <FILE id="zTtXbq" name="SortFilesSource.h" compile="0" resource="0"
-              file="/Users/shawley/github/vibrary/Source/SortFilesSource.h"/>
+              file="Source/SortFilesSource.h"/>
         <FILE id="GDHrx6" name="SpectrogramWriter.cpp" compile="1" resource="0"
               file="Source/SpectrogramWriter.cpp"/>
         <FILE id="ieEEYT" name="SpectrogramWriter.h" compile="0" resource="0"
               file="Source/SpectrogramWriter.h"/>
-        <FILE id="s3q95h" name="TagsSource.cpp" compile="1" resource="0" file="/Users/shawley/github/vibrary/Source/TagsSource.cpp"/>
-        <FILE id="RWSeOv" name="TagsSource.h" compile="0" resource="0" file="/Users/shawley/github/vibrary/Source/TagsSource.h"/>
+        <FILE id="s3q95h" name="TagsSource.cpp" compile="1" resource="0" file="Source/TagsSource.cpp"/>
+        <FILE id="RWSeOv" name="TagsSource.h" compile="0" resource="0" file="Source/TagsSource.h"/>
       </GROUP>
       <FILE id="wTAxkQ" name="Player.cpp" compile="1" resource="0" file="Source/Player.cpp"/>
       <FILE id="HPZwHd" name="Player.h" compile="0" resource="0" file="Source/Player.h"/>

--- a/Vibrary.jucer
+++ b/Vibrary.jucer
@@ -3,7 +3,7 @@
 <JUCERPROJECT id="uiEZ1i" name="Vibrary" projectType="guiapp" jucerVersion="5.4.7"
               companyName="Art+Logic, Inc." companyCopyright="&#169; Art+Logic, Inc. 2018-2020"
               companyWebsite="https://www.artandlogic.com/" bundleIdentifier="com.artandlogic.vibrary"
-              maxBinaryFileSize="10485760" cppLanguageStandard="17" version="autolist1213121412131215-690558576-690558575-690558574-690558573-690558572-690558571-690558570"
+              maxBinaryFileSize="10485760" cppLanguageStandard="17" version="0.2.3"
               projectLineFeed="&#10;">
   <MAINGROUP id="aknjgw" name="Vibrary">
     <GROUP id="{38BB0C96-FA79-5495-9251-4C0AEAB83BF9}" name="Source">

--- a/Vibrary.jucer
+++ b/Vibrary.jucer
@@ -3,7 +3,7 @@
 <JUCERPROJECT id="uiEZ1i" name="Vibrary" projectType="guiapp" jucerVersion="5.4.7"
               companyName="Art+Logic, Inc." companyCopyright="&#169; Art+Logic, Inc. 2018-2020"
               companyWebsite="https://www.artandlogic.com/" bundleIdentifier="com.artandlogic.vibrary"
-              maxBinaryFileSize="10485760" cppLanguageStandard="17" version="0.1.0"
+              maxBinaryFileSize="10485760" cppLanguageStandard="17" version="autolist1213121412131215-690558576-690558575-690558574-690558573-690558572-690558571-690558570"
               projectLineFeed="&#10;">
   <MAINGROUP id="aknjgw" name="Vibrary">
     <GROUP id="{38BB0C96-FA79-5495-9251-4C0AEAB83BF9}" name="Source">
@@ -22,9 +22,9 @@
         <FILE id="oQDso3" name="icon-delete-tag.png" compile="0" resource="1"
               file="Resources/images/icon-delete-tag.png"/>
         <FILE id="GLrJe9" name="icon-play.png" compile="0" resource="1" file="Resources/images/icon-play.png"/>
-        <FILE id="s2wK6a" name="icon-plus-circle.png" compile="0" resource="1"
-              file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Resources/images/icon-plus-circle.png"/>
-        <FILE id="DKsqqP" name="icon-plus.png" compile="0" resource="1" file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Resources/images/icon-plus.png"/>
+        <FILE id="AIBu8O" name="icon-plus-circle.png" compile="0" resource="1"
+              file="Resources/images/icon-plus-circle.png"/>
+        <FILE id="zYZRP8" name="icon-plus.png" compile="0" resource="1" file="Resources/images/icon-plus.png"/>
         <FILE id="iTIgWq" name="image-settings.png" compile="0" resource="1"
               file="Resources/images/image-settings.png"/>
         <FILE id="wuPf8k" name="image-train.png" compile="0" resource="1" file="Resources/images/image-train.png"/>
@@ -82,10 +82,10 @@
         <FILE id="KfuOug" name="FileListView.cpp" compile="1" resource="0"
               file="Source/FileListView.cpp"/>
         <FILE id="TD2mSS" name="FileListView.h" compile="0" resource="1" file="Source/FileListView.h"/>
-        <FILE id="Hmavj6" name="FileToolBar.cpp" compile="1" resource="0" file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Source/FileToolBar.cpp"/>
-        <FILE id="VnJ8ek" name="FileToolBar.h" compile="0" resource="0" file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Source/FileToolBar.h"/>
+        <FILE id="fOYlQU" name="FileToolBar.cpp" compile="1" resource="0" file="Source/FileToolBar.cpp"/>
         <FILE id="Nu5pF0" name="HeaderLookAndFeel.cpp" compile="1" resource="0"
               file="Source/HeaderLookAndFeel.cpp"/>
+        <FILE id="bAekXs" name="FileToolBar.h" compile="0" resource="0" file="Source/FileToolBar.h"/>
         <FILE id="IhIyiS" name="HeaderLookAndFeel.h" compile="0" resource="0"
               file="Source/HeaderLookAndFeel.h"/>
         <FILE id="vxURWj" name="MainView.cpp" compile="1" resource="0" file="Source/MainView.cpp"/>
@@ -112,11 +112,11 @@
               file="Source/SortFileComboBox.cpp"/>
         <FILE id="yrd8VF" name="SortFileComboBox.h" compile="0" resource="0"
               file="Source/SortFileComboBox.h"/>
-        <FILE id="XVnqyQ" name="TagButton.cpp" compile="1" resource="0" file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Source/TagButton.cpp"/>
-        <FILE id="riey7v" name="TagButton.h" compile="0" resource="0" file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Source/TagButton.h"/>
-        <FILE id="cWALOe" name="TagTextEditor.cpp" compile="1" resource="0"
-              file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Source/TagTextEditor.cpp"/>
-        <FILE id="nymRWB" name="TagTextEditor.h" compile="0" resource="0" file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Source/TagTextEditor.h"/>
+        <FILE id="WRo9IT" name="TagButton.cpp" compile="1" resource="0" file="Source/TagButton.cpp"/>
+        <FILE id="ENQmOz" name="TagButton.h" compile="0" resource="0" file="Source/TagButton.h"/>
+        <FILE id="CmUavS" name="TagTextEditor.cpp" compile="1" resource="0"
+              file="Source/TagTextEditor.cpp"/>
+        <FILE id="vOnyVF" name="TagTextEditor.h" compile="0" resource="0" file="Source/TagTextEditor.h"/>
         <FILE id="SmYCbp" name="TagView.cpp" compile="1" resource="0" file="Source/TagView.cpp"/>
         <FILE id="nHeGA7" name="TagView.h" compile="0" resource="0" file="Source/TagView.h"/>
         <FILE id="rd6vF0" name="TextEditLookAndFeel.cpp" compile="1" resource="0"
@@ -134,8 +134,8 @@
       <FILE id="IUJqeD" name="MelFilter.cpp" compile="1" resource="0" file="Source/MelFilter.cpp"/>
       <FILE id="YzJnXk" name="MelFilter.h" compile="0" resource="0" file="Source/MelFilter.h"/>
       <GROUP id="{A6310410-E140-91C9-001E-5CE8F9F54FAA}" name="Model">
-        <FILE id="Tn26Qa" name="SortFile.cpp" compile="1" resource="0" file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Source/SortFile.cpp"/>
-        <FILE id="GVXsEQ" name="SortFile.h" compile="0" resource="0" file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Source/SortFile.h"/>
+        <FILE id="Tn26Qa" name="SortFile.cpp" compile="1" resource="0" file="/Users/shawley/github/vibrary/Source/SortFile.cpp"/>
+        <FILE id="GVXsEQ" name="SortFile.h" compile="0" resource="0" file="/Users/shawley/github/vibrary/Source/SortFile.h"/>
         <FILE id="L80SR0" name="Spectrogram.cpp" compile="1" resource="0" file="Source/Spectrogram.cpp"/>
         <FILE id="hAktFn" name="Spectrogram.h" compile="0" resource="0" file="Source/Spectrogram.h"/>
         <FILE id="I1A2M0" name="Tag.cpp" compile="1" resource="0" file="Source/Tag.cpp"/>
@@ -161,15 +161,15 @@
         <FILE id="prxoGb" name="Persistence.cpp" compile="1" resource="0" file="Source/Persistence.cpp"/>
         <FILE id="E6U4du" name="Persistence.h" compile="0" resource="0" file="Source/Persistence.h"/>
         <FILE id="X5McxC" name="SortFilesSource.cpp" compile="1" resource="0"
-              file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Source/SortFilesSource.cpp"/>
+              file="/Users/shawley/github/vibrary/Source/SortFilesSource.cpp"/>
         <FILE id="zTtXbq" name="SortFilesSource.h" compile="0" resource="0"
-              file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Source/SortFilesSource.h"/>
+              file="/Users/shawley/github/vibrary/Source/SortFilesSource.h"/>
         <FILE id="GDHrx6" name="SpectrogramWriter.cpp" compile="1" resource="0"
               file="Source/SpectrogramWriter.cpp"/>
         <FILE id="ieEEYT" name="SpectrogramWriter.h" compile="0" resource="0"
               file="Source/SpectrogramWriter.h"/>
-        <FILE id="s3q95h" name="TagsSource.cpp" compile="1" resource="0" file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Source/TagsSource.cpp"/>
-        <FILE id="RWSeOv" name="TagsSource.h" compile="0" resource="0" file="/System/Volumes/Data/Users/jason/src/AL/ArtLogic/Incubator1/Source/TagsSource.h"/>
+        <FILE id="s3q95h" name="TagsSource.cpp" compile="1" resource="0" file="/Users/shawley/github/vibrary/Source/TagsSource.cpp"/>
+        <FILE id="RWSeOv" name="TagsSource.h" compile="0" resource="0" file="/Users/shawley/github/vibrary/Source/TagsSource.h"/>
       </GROUP>
       <FILE id="wTAxkQ" name="Player.cpp" compile="1" resource="0" file="Source/Player.cpp"/>
       <FILE id="HPZwHd" name="Player.h" compile="0" resource="0" file="Source/Player.h"/>
@@ -213,9 +213,9 @@
     </GROUP>
   </MAINGROUP>
   <EXPORTFORMATS>
-    <XCODE_MAC targetFolder="Builds/MacOSX" externalLibraries="z" extraLinkerFlags="${PROJECT_DIR}/../../3rdParty/tensorflow/dist/lib/libtensorflow_framework.1.dylib&#10;${PROJECT_DIR}/../../3rdParty/tensorflow/dist/lib/libtensorflow_cc.so&#10;${PROJECT_DIR}/../../3rdParty/cnpy/dist/lib/libcnpy.a&#10;/usr/local/lib/libssh.4.8.4.dylib&#10;/usr/local/Cellar/libarchive/3.4.0/lib/libarchive.13.dylib&#10;-L/usr/local/opt/openssl/lib&#10;-rpath @loader_path/../Libraries"
+    <XCODE_MAC targetFolder="Builds/MacOSX" externalLibraries="z" extraLinkerFlags="${PROJECT_DIR}/../../3rdParty/tensorflow/dist/lib/libtensorflow_framework.1.dylib&#10;${PROJECT_DIR}/../../3rdParty/tensorflow/dist/lib/libtensorflow_cc.so&#10;${PROJECT_DIR}/../../3rdParty/cnpy/dist/lib/libcnpy.a&#10;/usr/local/lib/libssh.4.dylib&#10;/usr/local/opt/libarchive/lib/libarchive.13.dylib&#10;-L/usr/local/opt/openssl/lib&#10;-rpath @loader_path/../Libraries"
                postbuildCommand="${PROJECT_DIR}/../../Tools/PostBuildMac.sh"
-               extraCompilerFlags="-I../../3rdParty/tensorflow/dist/include/protobuf/src&#10;-I../../3rdParty/tensorflow/dist/include/tensorflow/eigen&#10;-I../../3rdParty/tensorflow/dist/include/tensorflow/bazel-genfiles&#10;-I../../3rdParty/tensorflow/dist/include/tensorflow&#10;-I../../3rdParty/tensorflow/dist/include&#10;-I../../3rdParty/cnpy/dist/include&#10;-I../../3rdParty/sqlite/src&#10;-I/usr/local/Cellar/libssh/0.9.3/include&#10;-I/usr/local/Cellar/libarchive/3.4.0/include"
+               extraCompilerFlags="-I../../3rdParty/tensorflow/dist/include/protobuf/src&#10;-I../../3rdParty/tensorflow/dist/include/tensorflow/eigen&#10;-I../../3rdParty/tensorflow/dist/include/tensorflow/bazel-genfiles&#10;-I../../3rdParty/tensorflow/dist/include/tensorflow&#10;-I../../3rdParty/tensorflow/dist/include&#10;-I../../3rdParty/cnpy/dist/include&#10;-I../../3rdParty/sqlite/src&#10;-I/usr/local/opt/libssh/include&#10;-I/usr/local/opt/libarchive/include"
                bigIcon="bGDFOG" smallIcon="bGDFOG" prebuildCommand="${PROJECT_DIR}/../../Tools/PreBuildMac.sh">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="Vibrary" defines="UNIT_TESTS=1"
@@ -305,7 +305,7 @@
     <MODULE id="juce_video" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
   </MODULES>
   <LIVE_SETTINGS>
-    <OSX buildEnabled="1"/>
+    <OSX buildEnabled="0"/>
   </LIVE_SETTINGS>
   <JUCEOPTIONS JUCE_PLUGINHOST_VST="0" JUCE_USE_MP3AUDIOFORMAT="1"/>
 </JUCERPROJECT>


### PR DESCRIPTION
Fixes described in https://github.com/artandlogic/vibrary/issues/2
Also updated project name from Incubator1 to Vibrary